### PR TITLE
Bug fix: Incorrect save of 'pairs'

### DIFF
--- a/dmd/generate.py
+++ b/dmd/generate.py
@@ -276,7 +276,7 @@ class EDMGenerator:
                     outdir,
                     images=images,
                     latents=latents,
-                    save_start_idx=save_start_idx
+                    save_start_idx=save_start_idx + batch_seeds[0]
                 )
 
         # Done.


### PR DESCRIPTION
`save_start_index` weren't incremented correctly for batches causing the incorrect save of tuples in 'pairs' mode.